### PR TITLE
fix(test): change port to avoid conflict with github actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+coverage/

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const app     = express();
-const port    = 80;
+const port    = 8080;
 const square = require("./lib/square")
 
 app.disable("x-powered-by")
@@ -14,9 +14,15 @@ app.get('/square/:nb', (req, res) => {
 	res.send(square(parseInt(nb)).toString());
 });
 
+let server;
 
-app.listen(port,() => {
+server = app.listen(port, () => {
     console.log(`Server is running on port ${port}`);
 });
 
-module.exports = app
+module.exports = {
+    app,
+    closeServer: () => {
+        server.close();
+    }
+};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const { app, closeServer } = require('./index');
+
+describe('Server is running', () => {
+    afterAll(() => {
+        closeServer();
+    });
+
+    it('Should return 200', async () => {
+        const res = await request(app).get('/');
+        expect(res.status).toBe(200);
+    });
+
+    it('Should return "hello world"', async () => {
+        const res = await request(app).get('/');
+        expect(res.text).toBe('hello world');
+    });
+});


### PR DESCRIPTION
## Description

Pour éviter un conflit avec le port 80 bloqué par Github actions on utilise le port 8080 et on permet d'utiliser la variable app dans les test et une methode close pour fermer l'instance du serveur.